### PR TITLE
add option to upload fasta reference sequence

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "License :: OSI Approved :: MIT License",
 ]
-dependencies = ["flask", "flask-cors", "flask-jwt-extended", "flask-sqlalchemy", "argon2-cffi", "click"]
+dependencies = ["flask", "flask-cors", "flask-jwt-extended", "flask-sqlalchemy", "argon2-cffi", "click", "biopython"]
 
 [project.scripts]
 circuit_seq_server = "circuit_seq_server.main:main"

--- a/backend/src/circuit_seq_server/logger.py
+++ b/backend/src/circuit_seq_server/logger.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import logging
 
 

--- a/backend/src/circuit_seq_server/primary_key.py
+++ b/backend/src/circuit_seq_server/primary_key.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Optional
 import string
 import math

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
     build:
       ./frontend
     ports:
-      - 8080:8080
+      - 80:80

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -11,7 +11,7 @@ RUN npm install
 RUN npm run build-only
 
 # debug server
-CMD ["npm", "run", "dev", "--", "--host", "--port", "8080"]
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "8080"]
 
 # production server
 # CMD ["http-server", "dist"]

--- a/frontend/src/api-client.ts
+++ b/frontend/src/api-client.ts
@@ -15,4 +15,27 @@ apiClient.interceptors.request.use(function (config) {
   return config;
 });
 
-export default apiClient;
+function download_reference_sequence(primary_key: string) {
+  apiClient
+    .post(
+      "reference_sequence",
+      {
+        primary_key: primary_key,
+      },
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+        responseType: "blob",
+      }
+    )
+    .then((response) => {
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", `${primary_key}_reference_sequence.fasta`);
+      document.body.appendChild(link);
+      link.click();
+    });
+}
+export { apiClient, download_reference_sequence };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -4,6 +4,7 @@ export type Sample = {
   primary_key: string;
   name: string;
   email: string;
+  reference_sequence_description: string | null;
   // date: Date;
 };
 

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import Item from "@/components/ListItem.vue";
 import { ref } from "vue";
-import apiClient from "@/api-client";
+import { apiClient } from "@/api-client";
 const remaining = ref(0);
 apiClient.get("remaining").then((response) => {
   console.log(response);
@@ -39,9 +39,10 @@ apiClient.get("remaining").then((response) => {
         <i class="bi-book"></i>
       </template>
       <template #heading>References</template>
-      This software implements a variant of the Circuit-seq method published by the McKenna lab:
+      This software implements a variant of the Circuit-seq method published by
+      the McKenna lab:
       <a href="https://pubs.acs.org/doi/pdf/10.1021/acssynbio.2c00126"
-      >ACS Synth. Biol. 2022, 11, 2238−2246</a
+        >ACS Synth. Biol. 2022, 11, 2238−2246</a
       >
     </Item>
     <Item>
@@ -51,7 +52,7 @@ apiClient.get("remaining").then((response) => {
       <template #heading>Funding</template>
       This work was funded by the
       <a href="https://www.health-life-sciences.de/?lang=de"
-      >Heidelberg Mannheim Life Sciences alliance</a
+        >Heidelberg Mannheim Life Sciences alliance</a
       >
       through an 'Explore!Tech' grant awarded to Drs Ed Green, Liam Keegan and
       Kim Remans.

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -2,7 +2,7 @@
 import Item from "@/components/ListItem.vue";
 import { ref } from "vue";
 import type { Sample, User } from "@/types";
-import apiClient from "@/api-client";
+import { apiClient, download_reference_sequence } from "@/api-client";
 
 const samples = ref([] as Sample[]);
 apiClient.get("allsamples").then((response) => {
@@ -30,13 +30,25 @@ apiClient.get("allusers").then((response) => {
           <th>Primary Key</th>
           <th>Email</th>
           <th>Sample Name</th>
-          <th>Requested on</th>
+          <th>Reference Sequence</th>
         </tr>
         <tr v-for="sample in samples" :key="sample.id">
           <td>{{ sample["primary_key"] }}</td>
           <td>{{ sample["email"] }}</td>
           <td>{{ sample["name"] }}</td>
-          <!--          <td>{{ sample["date"].toUTCString() }}</td>-->
+          <td>
+            <template v-if="sample['reference_sequence_description']">
+              <a
+                href=""
+                @click.prevent="
+                  download_reference_sequence(sample['primary_key'])
+                "
+              >
+                {{ sample["reference_sequence_description"] }}
+              </a>
+            </template>
+            <template v-else> - </template>
+          </td>
         </tr>
       </table>
     </Item>

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -2,7 +2,7 @@
 import Item from "@/components/ListItem.vue";
 import { ref, computed } from "vue";
 import { useUserStore } from "@/stores/user";
-import apiClient from "@/api-client";
+import { apiClient } from "@/api-client";
 
 const userStore = useUserStore();
 


### PR DESCRIPTION
- user can optionally upload a file when requesting a sample
  - it is parsed by the backend as a fasta file using biopython
  - if successfully parsed:
    - first record is written to `PRIMARYKEY_SAMPLENAME.fasta` file on server
    - first record description is added to the sample in the samples database
- user samples list includes link to reference sequences
  - click on link downloads the fasta file
  - add `/reference_sequence` POST endpoint to backend
  - download via blob in memory instead of direct http to allow use of JWT authentication header
- resolves #1
- also expose docker frontend to port 80 for deployment
