### PR TITLE
Add running option to sample

### DIFF
--- a/backend/src/circuit_seq_server/app.py
+++ b/backend/src/circuit_seq_server/app.py
@@ -91,6 +91,12 @@ def create_app(data_path: str = "/circuit_seq_data"):
             - count_samples_this_week()
         )
 
+    @app.route("/running_options", methods=["GET"])
+    @jwt_required()
+    def running_options():
+        settings = get_current_settings()
+        return jsonify(running_options=settings["running_options"])
+
     @app.route("/samples", methods=["GET"])
     @jwt_required()
     def samples():
@@ -157,9 +163,12 @@ def create_app(data_path: str = "/circuit_seq_data"):
     def add_sample():
         email = current_user.email
         name = request.form.to_dict().get("name", "")
+        running_option = request.form.to_dict().get("running_option", "")
         reference_sequence_file = request.files.to_dict().get("file", None)
         logger.info(f"Adding sample {name} from {email}")
-        new_sample = add_new_sample(email, name, reference_sequence_file, data_path)
+        new_sample = add_new_sample(
+            email, name, running_option, reference_sequence_file, data_path
+        )
         if new_sample is not None:
             logger.info(f"  - > success")
             return jsonify(sample=new_sample)

--- a/backend/src/circuit_seq_server/model.py
+++ b/backend/src/circuit_seq_server/model.py
@@ -28,7 +28,11 @@ class Settings(db.Model):
 
 
 def default_settings_dict() -> Dict:
-    return {"plate_n_rows": 8, "plate_n_cols": 12}
+    return {
+        "plate_n_rows": 8,
+        "plate_n_cols": 12,
+        "running_options": ["dna_r9.4.1_450bps_sup.cfg", "dna_r9.4.1_480bps_sup.cfg"],
+    }
 
 
 def get_current_settings() -> Dict:
@@ -69,6 +73,7 @@ class Sample(db.Model):
     email: str = db.Column(db.String(256), nullable=False)
     primary_key: str = db.Column(db.String(32), nullable=False, unique=True)
     name: str = db.Column(db.String(128), nullable=False)
+    running_option: str = db.Column(db.String(128), nullable=False)
     reference_sequence_description: Optional[str] = db.Column(
         db.String(256), nullable=True
     )
@@ -106,6 +111,7 @@ def _write_samples_as_tsv_this_week(
                 "primary_key",
                 "email",
                 "name",
+                "running_option",
             ]
         )
         for sample_tuple in current_samples:
@@ -117,6 +123,7 @@ def _write_samples_as_tsv_this_week(
                     sample.primary_key,
                     sample.email,
                     sample.name,
+                    sample.running_option,
                 ]
             )
     return filename
@@ -212,6 +219,7 @@ def add_new_user(
 def add_new_sample(
     email: str,
     name: str,
+    running_option: str,
     reference_sequence_file: Optional[Any],
     data_path: str,
 ) -> Optional[Sample]:
@@ -257,6 +265,7 @@ def add_new_sample(
         name=name,
         primary_key=key,
         reference_sequence_description=reference_sequence_description,
+        running_option=running_option,
         date=today,
     )
     db.session.add(new_sample)
@@ -276,6 +285,7 @@ def _add_temporary_users_for_testing():
 
 def _add_temporary_samples_for_testing():
     # add temporary samples if not already in db
+    running_option = get_current_settings()["running_options"][0]
     for week in [43, 42, 40]:
         for n in [1, 2, 3]:
             key = f"22_{week}_A{n}"
@@ -287,6 +297,7 @@ def _add_temporary_samples_for_testing():
                     name=f"builtin_test_sample{n}",
                     primary_key=key,
                     reference_sequence_description=None,
+                    running_option=running_option,
                     date=datetime.date.fromisocalendar(2022, week, n),
                 )
                 db.session.add(new_sample)

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -54,6 +54,19 @@ def test_samples_valid(client):
     assert "previous_samples" in response.json
 
 
+def test_running_options_invalid(client):
+    # no auth header
+    response = client.get("/running_options")
+    assert response.status_code == 401
+
+
+def test_running_options_valid(client):
+    headers = _get_auth_headers(client)
+    response = client.get("/running_options", headers=headers)
+    assert response.status_code == 200
+    assert "running_options" in response.json
+
+
 def test_admin_settings_invalid(client):
     # no auth header
     response = client.get("/admin/settings")
@@ -73,7 +86,11 @@ def test_admin_settings_valid(client):
     # set new valid settings
     response = client.post(
         "/admin/settings",
-        json={"plate_n_rows": 14, "plate_n_cols": 18},
+        json={
+            "plate_n_rows": 14,
+            "plate_n_cols": 18,
+            "running_options": ["o1", "o2", "o3"],
+        },
         headers=headers,
     )
     assert response.status_code == 200
@@ -81,6 +98,7 @@ def test_admin_settings_valid(client):
     assert response.status_code == 200
     assert response.json["plate_n_rows"] == 14
     assert response.json["plate_n_cols"] == 18
+    assert response.json["running_options"] == ["o1", "o2", "o3"]
 
 
 def test_admin_allsamples_invalid(client):
@@ -136,4 +154,4 @@ def test_admin_zipsamples_valid(client):
     assert len(zip_file.filelist) == 1
     assert zip_file.filelist[0].filename == "samples.tsv"
     tsv = zip_file.read("samples.tsv")
-    assert tsv == b"date\tprimary_key\temail\tname\n"
+    assert tsv == b"date\tprimary_key\temail\tname\trunning_option\n"

--- a/backend/tests/test_model.py
+++ b/backend/tests/test_model.py
@@ -10,7 +10,7 @@ def _count_settings() -> int:
 
 def test_settings(app, tmp_path):
     with app.app_context():
-        assert _count_settings() == 0
+        assert _count_settings() == 1
         settings = model.get_current_settings()
         assert _count_settings() == 1
         assert settings["plate_n_rows"] == 8
@@ -33,7 +33,8 @@ def test_settings(app, tmp_path):
         assert new_settings["plate_n_rows"] == 14
         assert new_settings["plate_n_cols"] == 18
         msg, code = model.set_current_settings(
-            email, {"plate_n_rows": 10, "plate_n_cols": 2}
+            email,
+            {"plate_n_rows": 10, "plate_n_cols": 2, "running_options": ["x", "y"]},
         )
         assert code == 200
         assert "Settings updated" in msg
@@ -41,6 +42,7 @@ def test_settings(app, tmp_path):
         new_settings = model.get_current_settings()
         assert new_settings["plate_n_rows"] == 10
         assert new_settings["plate_n_cols"] == 2
+        assert new_settings["running_options"] == ["x", "y"]
 
 
 def test_add_new_sample(app, tmp_path):
@@ -53,10 +55,13 @@ def test_add_new_sample(app, tmp_path):
         assert len(model.db.session.execute(this_week_samples).scalars().all()) == 0
         assert model.count_samples_this_week() == 0
         # add a sample without a reference sequence
-        new_sample = model.add_new_sample("u1@embl.de", "s1", None, str(tmp_path))
+        new_sample = model.add_new_sample(
+            "u1@embl.de", "s1", "running option", None, str(tmp_path)
+        )
         assert new_sample is not None
         assert new_sample.email == "u1@embl.de"
         assert new_sample.name == "s1"
+        assert new_sample.running_option == "running option"
         assert new_sample.primary_key == f"{year%100}_{week}_A1"
         assert new_sample.date == current_date
         assert new_sample.reference_sequence_description is None

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -19,4 +19,7 @@ module.exports = {
   parserOptions: {
     ecmaVersion: "latest",
   },
+  rules: {
+    "vue/require-v-for-key": "warn",
+  },
 };

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -1,9 +1,9 @@
 export type Sample = {
   id: number;
-  // label: string;
   primary_key: string;
   name: string;
   email: string;
+  running_option: string;
   reference_sequence_description: string | null;
   date: string;
 };
@@ -18,4 +18,7 @@ export type User = {
 export type Settings = {
   plate_n_rows: number;
   plate_n_cols: number;
+  running_options: Array<string>;
 };
+
+export type RunningOptions = Array<string>;

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -22,10 +22,22 @@ apiClient.get("admin/allusers").then((response) => {
 });
 
 const settings = ref({} as Settings);
+const new_running_option = ref("");
 const settings_message = ref("");
 apiClient.get("admin/settings").then((response) => {
   settings.value = response.data;
 });
+
+function add_running_option() {
+  settings.value.running_options.push(new_running_option.value);
+  new_running_option.value = "";
+}
+
+function remove_running_option(option: string) {
+  settings.value.running_options = settings.value.running_options.filter(
+    (t) => t !== option
+  );
+}
 
 function update_n_rows(event: Event) {
   const target = event.target as HTMLInputElement;
@@ -69,6 +81,7 @@ function save_settings() {
           <th>Primary Key</th>
           <th>Email</th>
           <th>Sample Name</th>
+          <th>Running Option</th>
           <th>Reference Sequence</th>
         </tr>
         <tr v-for="sample in current_samples" :key="sample.id">
@@ -76,6 +89,7 @@ function save_settings() {
           <td>{{ sample["primary_key"] }}</td>
           <td>{{ sample["email"] }}</td>
           <td>{{ sample["name"] }}</td>
+          <td>{{ sample["running_option"] }}</td>
           <td>
             <template v-if="sample['reference_sequence_description']">
               <a
@@ -130,6 +144,23 @@ function save_settings() {
           <td>{{ plate_range_string }}</td>
         </tr>
         <tr>
+          <td>Running options:</td>
+          <td>
+            <ul>
+              <li v-for="option in settings.running_options">
+                {{ option }}
+                <button @click="remove_running_option(option)">x</button>
+              </li>
+              <li>
+                <form @submit.prevent="add_running_option">
+                  <input v-model="new_running_option" maxlength="256" />
+                  <button>add</button>
+                </form>
+              </li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
           <td></td>
           <td>
             <button @click="save_settings">Save Settings</button>
@@ -151,6 +182,7 @@ function save_settings() {
           <th>Primary Key</th>
           <th>Email</th>
           <th>Sample Name</th>
+          <th>Running Option</th>
           <th>Reference Sequence</th>
         </tr>
         <tr v-for="sample in previous_samples" :key="sample.id">
@@ -158,6 +190,7 @@ function save_settings() {
           <td>{{ sample["primary_key"] }}</td>
           <td>{{ sample["email"] }}</td>
           <td>{{ sample["name"] }}</td>
+          <td>{{ sample["running_option"] }}</td>
           <td>
             <template v-if="sample['reference_sequence_description']">
               <a

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -93,13 +93,14 @@ function do_signup() {
               <input
                 v-model="login_email_address"
                 placeholder="your.name@uni-heidelberg.de"
+                maxlength="256"
               />
             </td>
           </tr>
           <tr>
             <td style="text-align: right">Password:</td>
             <td>
-              <input v-model="login_password" type="password" />
+              <input v-model="login_password" type="password" maxlength="256" />
             </td>
             <td>{{ login_error_message }}</td>
           </tr>
@@ -129,6 +130,7 @@ function do_signup() {
               v-model="signup_email_address"
               placeholder="your.name@uni-heidelberg.de"
               :title="signup_email_address_message"
+              maxlength="256"
             />
           </td>
           <td style="font-style: italic">{{ signup_email_address_message }}</td>
@@ -141,6 +143,7 @@ function do_signup() {
               type="password"
               placeholder="password"
               :title="signup_password_message"
+              maxlength="256"
             />
           </td>
           <td style="font-style: italic">{{ signup_password_message }}</td>

--- a/frontend/src/views/SamplesView.vue
+++ b/frontend/src/views/SamplesView.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from "vue";
 import Item from "@/components/ListItem.vue";
 import { apiClient, download_reference_sequence } from "@/utils/api-client";
-import type { Sample } from "@/utils/types";
+import type { Sample, RunningOptions } from "@/utils/types";
 const new_sample_name = ref("");
 const selected_file = ref(null as null | Blob);
 
@@ -56,9 +56,25 @@ apiClient
     console.log(error);
   });
 
+const running_options = ref([] as RunningOptions);
+const new_running_option = ref("");
+
+apiClient
+  .get("running_options")
+  .then((response) => {
+    running_options.value = response.data.running_options;
+    if (running_options.value.length > 0) {
+      new_running_option.value = running_options.value[0];
+    }
+  })
+  .catch((error) => {
+    console.log(error);
+  });
+
 function add_sample() {
   let formData = new FormData();
   formData.append("name", new_sample_name.value);
+  formData.append("running_option", new_running_option.value);
   if (selected_file.value !== null) {
     formData.append("file", selected_file.value);
   }
@@ -75,6 +91,7 @@ function add_sample() {
   selected_file.value = null;
 }
 </script>
+
 <template>
   <main>
     <Item>
@@ -88,11 +105,13 @@ function add_sample() {
           <tr>
             <th>Primary Key</th>
             <th>Sample Name</th>
+            <th>Running Option</th>
             <th>Reference Sequence</th>
           </tr>
           <tr v-for="sample in current_samples" :key="sample.id">
             <td>{{ sample["primary_key"] }}</td>
             <td>{{ sample["name"] }}</td>
+            <td>{{ sample["running_option"] }}</td>
             <td>
               <template v-if="sample['reference_sequence_description']">
                 <a
@@ -140,6 +159,16 @@ function add_sample() {
           </td>
         </tr>
         <tr>
+          <td style="text-align: right">Running option:</td>
+          <td>
+            <select v-model="new_running_option">
+              <option v-for="running_option in running_options">
+                {{ running_option }}
+              </option>
+            </select>
+          </td>
+        </tr>
+        <tr>
           <td style="text-align: right">Reference sequence (optional):</td>
           <td>
             <input
@@ -176,12 +205,14 @@ function add_sample() {
             <th>Date</th>
             <th>Primary Key</th>
             <th>Sample Name</th>
+            <td>Running Option</td>
             <th>Reference Sequence</th>
           </tr>
           <tr v-for="sample in previous_samples" :key="sample.id">
             <td>{{ new Date(sample["date"]).toLocaleDateString("en-CA") }}</td>
             <td>{{ sample["primary_key"] }}</td>
             <td>{{ sample["name"] }}</td>
+            <td>{{ sample["running_option"] }}</td>
             <td>
               <template v-if="sample['reference_sequence_description']">
                 <a


### PR DESCRIPTION
- add running_options to settings dict
  - this is a list of strings
  - can be edited in the admin page
  - first item in list is the default running option
  - add `/running_options` endpoint to retrieve this
- add drop-down running option to samples
  - offers a choice of the values in the running_options list in settings
- add running option to samples table
- resolves #6
