### PR TITLE
API tokens remain valid when server restarts

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -7,7 +7,8 @@ import pathlib
 
 
 @pytest.fixture()
-def app(tmp_path):
+def app(monkeypatch, tmp_path):
+    monkeypatch.setenv("JWT_SECRET_KEY", "abcdefghijklmnopqrstuvwxyz")
     temp_data_path = str(tmp_path)
     app = create_app(data_path=temp_data_path)
     yield app

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -3,6 +3,7 @@ import io
 import zipfile
 from freezegun import freeze_time
 import pathlib
+import circuit_seq_server
 
 
 @freeze_time("2022-11-21")
@@ -47,6 +48,33 @@ def test_login_valid(client):
     assert "access_token" in response.json
     assert response.json["user"]["email"] == email
     assert response.json["user"]["is_admin"] is False
+
+
+def test_jwt_same_secret_persists_valid_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_KEY", "0123456789abcdefghijklmnopqrstuvwxyz")
+    app1 = circuit_seq_server.create_app(data_path=str(tmp_path))
+    client1 = app1.test_client()
+    headers1 = _get_auth_headers(client1)
+    assert client1.get("/samples", headers=headers1).status_code == 200
+    # create new app with same JWT secret key
+    app2 = circuit_seq_server.create_app(data_path=str(tmp_path))
+    client2 = app2.test_client()
+    # can re-use the same JWT token in the new app
+    assert client2.get("/samples", headers=headers1).status_code == 200
+
+
+def test_jwt_different_secret_invalidates_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("JWT_SECRET_KEY", "")  # too short: uses random one instead
+    app1 = circuit_seq_server.create_app(data_path=str(tmp_path))
+    client1 = app1.test_client()
+    headers1 = _get_auth_headers(client1)
+    assert client1.get("/samples", headers=headers1).status_code == 200
+    # create new app with a different JWT secret key
+    monkeypatch.setenv("JWT_SECRET_KEY", "")  # too short: uses random one instead
+    app2 = circuit_seq_server.create_app(data_path=str(tmp_path))
+    client2 = app2.test_client()
+    # can't re-use the same JWT token in the new app
+    assert client2.get("/samples", headers=headers1).status_code == 422
 
 
 def test_samples_invalid(client):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - ${CIRCUIT_SEQ_DATA:-./docker_volume}:/circuit_seq_data
       - ${CIRCUIT_SEQ_SSL_CERT:-./cert.pem}:/circuit_seq_ssl_cert.pem
       - ${CIRCUIT_SEQ_SSL_KEY:-./key.pem}:/circuit_seq_ssl_key.pem
+    environment:
+      - JWT_SECRET_KEY=${CIRCUIT_SEQ_JWT_SECRET_KEY:-}
   frontend:
     build: ./frontend
     ports:

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -170,8 +170,7 @@ function upload_result(event: Event) {
       <p>
         Here you can generate an admin API token to interact programmatically
         with the backend. Note this token should be kept secret! It is valid for
-        1 year (or until the backend is restarted), then you will need to
-        generate a new one.
+        6 months, then you will need to generate a new one.
       </p>
       <p>
         <button @click="generate_api_token">


### PR DESCRIPTION
- jwt secret key is read from the `JWT_SECRET_KEY` environment variable
  - add `CIRCUIT_SEQ_JWT_SECRET_KEY=abc123...` to .env file on production server to set this env var inside the backend docker container
  - require a length of at least 16 chars
  - if not provided or too short fall-back to previous behaviour: generate a random secret on startup
- keeping the same key means long-lived API keys remain valid even if the server is restarted
- change lifetime of admin API key to 6 months
- resolves #55
