### PR TITLE
add email activation step to signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,32 +9,29 @@ A work-in-progress prototype of the CircuitSEQ website.
 
 It is now running on a heiCLOUD VM here: https://circuitseq.iwr.uni-heidelberg.de/
 
-### Testing accounts
+You can sign up for a user account using any valid heidelberg/embl/dkfz email address.
 
-There are currently two built-in accounts for testing purposes:
-
-- admin account
-  - email: `admin@embl.de`
-  - password: `admin`
-- user account
-  - email: `user@embl.de`
-  - password: `user`
-
-You can also signup for a new account on the site (there is not yet an email account activation step, you can login straightaway after signup)
-
-### Implemented features
+## Implemented features
 
 - Users can
   - sign up with a valid email address
-  - request a sample, optionally providing a fasta reference sequence
-  - see a list of their requested samples & download the reference sequences
+  - request a sample, optionally providing a reference sequence
+  - see a list of their requested samples
+  - download their reference sequences
+  - download their results
 - Admins can
-  - see a list of all requested samples & download reference sequences
   - see a list of all users
+  - see a list of all requested samples
+  - change the site settings
+    - set which day of the week sample submission closes
+    - set number of plate rows/cols
+    - add/remove running options
+  - download a zipped tsv of this weeks requests including reference sequences as fasta files
+  - also do all of the above using a REST API
 
-### Notes
+## Notes
 
-- all uploaded samples and registered users will be deleted without warning as the prototype is updated!
+- currently all uploaded samples and registered users may be deleted without warning as the prototype is updated!
 
 ## Developer info
 

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -30,11 +30,16 @@ To generate a cert/key pair:
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes -subj '/CN=localhost'
 ```
 
+### Secret Key
+
+JWT tokens used for authentication are generated using a secret key.
+This can be set using the `CIRCUIT_SEQ_JWT_SECRET_KEY` environment variable.
+If this is not set or is less than 16 chars, a new random secret key is generated when the server starts.
+
 ### URL
 
 The website is then served at https://localhost/
-
-Note that these are self-signed keys and your browser will still warn about the site being insecure.
+Note that the SSK keys are self-signed keys and your browser will still warn about the site being insecure.
 
 ## Run locally with Python and npm
 
@@ -82,3 +87,28 @@ Both the backend and the frontend have a Dockerfile, and there is docker-compose
 
 Same as docker-compose but with additional `.env` and `frontend/.env.local` files
 to set location of database, cert/key pair from letsencrypt, and public url.
+
+### To deploy
+
+```
+cd circuit_seq
+# check current status
+sudo docker-compose ps
+# see current logs
+sudo docker-compose logs
+# update code
+git fetch && git pull
+# re-build & re-launch containers
+sudo docker-compose up --build -d
+```
+
+### Make admin users
+
+To make an existing user with email `user@embl.de` into an admin, ssh into the VM, then
+
+```
+cd circuit_seq
+sudo sqlite3 docker_volume/CircuitSeq.db
+sqlite> UPDATE user SET is_admin=true WHERE email='user@embl.de';
+sqlite> .quit
+```

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "biopython",
   "gunicorn",
   "snapgene_reader",
+  "itsdangerous",
 ]
 
 [project.scripts]

--- a/backend/src/circuit_seq_server/app.py
+++ b/backend/src/circuit_seq_server/app.py
@@ -20,14 +20,13 @@ from circuit_seq_server.model import (
     Sample,
     User,
     add_new_user,
+    activate_user,
     add_new_sample,
     remaining_samples_this_week,
     get_current_settings,
     set_current_settings,
     update_samples_zipfile,
     process_result,
-    _add_temporary_users_for_testing,
-    _add_temporary_samples_for_testing,
 )
 
 
@@ -96,7 +95,12 @@ def create_app(data_path: str = "/circuit_seq_data"):
         email = request.json.get("email", None)
         password = request.json.get("password", None)
         logger.info(f"Signup request from {email}")
-        message, code = add_new_user(email, password)
+        message, code = add_new_user(email, password, False)
+        return jsonify(message=message), code
+
+    @app.route("/activate/<token>")
+    def activate(token: str):
+        message, code = activate_user(token)
         return jsonify(message=message), code
 
     @app.route("/remaining", methods=["GET"])
@@ -306,7 +310,5 @@ def create_app(data_path: str = "/circuit_seq_data"):
 
     with app.app_context():
         db.create_all()
-        _add_temporary_users_for_testing()
-        _add_temporary_samples_for_testing()
 
     return app

--- a/backend/src/circuit_seq_server/utils.py
+++ b/backend/src/circuit_seq_server/utils.py
@@ -7,8 +7,25 @@ import string
 import math
 from Bio import SeqIO
 import snapgene_reader
+from itsdangerous.url_safe import URLSafeSerializer
 
 logger = get_logger("CircuitSeqServer")
+
+
+def encode_activation_token(email: str, secret_key: str) -> str:
+    ss = URLSafeSerializer(secret_key, salt="activate")
+    return ss.dumps(email)
+
+
+def decode_activation_token(token: str, secret_key: str) -> Optional[str]:
+    ss = URLSafeSerializer(secret_key, salt="activate")
+    one_week_in_secs = 60 * 60 * 24 * 7
+    try:
+        email = ss.loads(token, max_age=one_week_in_secs)
+    except Exception as e:
+        logger.warn(f"Invalid or expired activation token: {e}")
+        return None
+    return email
 
 
 def get_start_of_week(current_date: Optional[datetime.date] = None) -> datetime.date:

--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -1,0 +1,52 @@
+from flask_sqlalchemy import SQLAlchemy
+import argon2
+from circuit_seq_server.model import User, Sample
+import datetime
+
+
+def add_test_users(app):
+    db = SQLAlchemy(app)
+    ph = argon2.PasswordHasher()
+    with app.app_context():
+        # add users for tests
+        for (name, is_admin) in [("admin", True), ("user", False)]:
+            email = f"{name}@embl.de"
+            db.session.add(
+                User(
+                    email=email,
+                    password_hash=ph.hash(name),
+                    activated=True,
+                    is_admin=is_admin,
+                )
+            )
+            db.session.commit()
+
+
+def add_test_samples(app):
+    db = SQLAlchemy(app)
+    with app.app_context():
+        # add samples for tests
+        week = 46
+        for n, name in zip(
+            [1, 2, 3, 4],
+            [
+                "no_ref_seq",
+                "ZIP_TEST_pMC_Final_Kan",
+                "ZIP_TEST_pCW571",
+                "ZIP_TEST_pDONR_amilCP",
+            ],
+        ):
+            key = f"22_{week}_A{n}"
+            new_sample = Sample(
+                email="user@embl.de",
+                name=name,
+                primary_key=key,
+                reference_sequence_description=None,
+                running_option="running_option",
+                date=datetime.date.fromisocalendar(2022, week, n),
+                has_results_zip=False,
+                has_results_fasta=False,
+                has_results_gbk=False,
+            )
+            db.session.add(new_sample)
+            db.session.commit()

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from circuit_seq_server.utils import get_primary_key
 import datetime
 from circuit_seq_server.utils import get_start_of_week

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,7 @@ services:
     volumes:
       - ${CIRCUIT_SEQ_SSL_CERT:-./cert.pem}:/circuit_seq_ssl_cert.pem
       - ${CIRCUIT_SEQ_SSL_KEY:-./key.pem}:/circuit_seq_ssl_key.pem
+  email:
+    image: "boky/postfix"
+    environment:
+      - ALLOW_EMPTY_SENDER_DOMAINS="true"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "circuit_seq",
       "version": "0.0.0",
       "dependencies": {
-        "bootstrap-icons": "^1.9.1",
+        "bootstrap-icons": "^1.10.2",
         "pinia": "^2.0.21",
         "vue": "^3.2.38",
         "vue-router": "^4.1.5"
@@ -3857,9 +3857,9 @@
       "dev": true
     },
     "node_modules/bootstrap-icons": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.9.1.tgz",
-      "integrity": "sha512-d4ZkO30MIkAhQ2nNRJqKXJVEQorALGbLWTuRxyCTJF96lRIV6imcgMehWGJUiJMJhglN0o2tqLIeDnMdiQEE9g=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.2.tgz",
+      "integrity": "sha512-PTPYadRn1AMGr+QTSxe4ZCc+Wzv9DGZxbi3lNse/dajqV31n2/wl/7NX78ZpkvFgRNmH4ogdIQPQmxAfhEV6nA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -13839,9 +13839,9 @@
       "dev": true
     },
     "bootstrap-icons": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.9.1.tgz",
-      "integrity": "sha512-d4ZkO30MIkAhQ2nNRJqKXJVEQorALGbLWTuRxyCTJF96lRIV6imcgMehWGJUiJMJhglN0o2tqLIeDnMdiQEE9g=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.10.2.tgz",
+      "integrity": "sha512-PTPYadRn1AMGr+QTSxe4ZCc+Wzv9DGZxbi3lNse/dajqV31n2/wl/7NX78ZpkvFgRNmH4ogdIQPQmxAfhEV6nA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path ../.gitignore"
   },
   "dependencies": {
-    "bootstrap-icons": "^1.9.1",
+    "bootstrap-icons": "^1.10.2",
     "pinia": "^2.0.21",
     "vue": "^3.2.38",
     "vue-router": "^4.1.5"

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -16,6 +16,12 @@ const router = createRouter({
       component: () => import("../views/LoginView.vue"),
     },
     {
+      path: "/activate/:activation_token",
+      name: "activate",
+      component: () => import("../views/ActivateView.vue"),
+      props: true,
+    },
+    {
       path: "/samples",
       name: "samples",
       component: () => import("../views/SamplesView.vue"),

--- a/frontend/src/views/ActivateView.vue
+++ b/frontend/src/views/ActivateView.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import Item from "@/components/ListItem.vue";
+import { ref } from "vue";
+import { apiClient } from "@/utils/api-client";
+const props = defineProps({ activation_token: String });
+
+const status_message = ref("");
+const message = ref("");
+const icon_name = ref("bi-person-exclamation");
+
+apiClient
+  .get(`activate/${props.activation_token}`)
+  .then((response) => {
+    console.log(response);
+    message.value = response.data.message;
+    icon_name.value = "bi-person-check";
+    status_message.value = "Successful";
+  })
+  .catch((error) => {
+    if (error.response != null) {
+      message.value = error.response.data.message;
+    } else {
+      message.value = "Cannot connect to server.";
+    }
+    icon_name.value = "bi-person-exclamation";
+    status_message.value = "Failed";
+  });
+</script>
+
+<template>
+  <main>
+    <Item>
+      <template #icon>
+        <p><i :class="icon_name"></i></p>
+      </template>
+      <template #heading>Account Activation {{ status_message }}</template>
+      <p>{{ message }}</p>
+      <p>Go to <RouterLink to="/login">login / signup</RouterLink> page.</p>
+    </Item>
+  </main>
+</template>


### PR DESCRIPTION
- /signup
  - uses itsdangerous to encode the email as a url-safe token
  - generates an activation url from this token
  - sends an email to the user to confirm their address with this url
- /activate endpoint
  - converts the token to a user email
  - if valid, activates this user
  - returns a message
- add ActivateView
  - takes the activation token as part of url
    - /activate/[token]
  - calls the activate endpoint with this token
  - displays result to user
- add a send-only postfix docker image to docker-compose
  - other docker containers can access the smtp server at `email:587`
  - this is not accessible outside of the docker network within the VM
- remove test user accounts and samples from production database
- add test user and samples to tests
- resolves #16
