### PR TITLE
build & publish production docker images in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,9 @@ jobs:
       - run: npm run test:unit:ci
       # todo: these e2e tests are not generating coverage reports on CI:
       - run: DEBUG=cypress:* npm run test:e2e:ci
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./frontend/coverage/coverage-final.json
           name: ${{ matrix.node-version }}
           fail_ci_if_error: true
@@ -60,8 +61,9 @@ jobs:
           openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes -subj '/CN=localhost'
           circuit_seq_server --help
           timeout 5 circuit_seq_server || [ "$?" -eq 124 ]
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./backend/coverage.xml
           name: ${{ matrix.python-version }}
           fail_ci_if_error: true
@@ -71,4 +73,25 @@ jobs:
     name: "Docker"
     steps:
       - uses: actions/checkout@v3
+      - run: echo "VITE_REST_API_LOCATION=https://circuitseq.iwr.uni-heidelberg.de:8080" > frontend/.env
       - run: docker-compose build
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - run: |
+          echo $CIRCUIT_SEQ_DOCKER_IMAGE_TAG
+          docker-compose build
+          docker-compose push
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          CIRCUIT_SEQ_DOCKER_IMAGE_TAG: ${{ github.sha }}
+      - run: |
+          echo $CIRCUIT_SEQ_DOCKER_IMAGE_TAG
+          docker-compose build
+          docker-compose push
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          CIRCUIT_SEQ_DOCKER_IMAGE_TAG: "latest"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.10-slim
 
+LABEL org.opencontainers.image.source=https://github.com/ssciwr/circuit_seq
+LABEL org.opencontainers.image.description="CircuitSEQ backend production image"
+LABEL org.opencontainers.image.licenses=MIT
+
 WORKDIR /app
 
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   backend:
+    image: ghcr.io/ssciwr/circuit_seq_backend:${CIRCUIT_SEQ_DOCKER_IMAGE_TAG:-latest}
     build: ./backend
     ports:
       - 8080:8080
@@ -10,6 +11,7 @@ services:
     environment:
       - JWT_SECRET_KEY=${CIRCUIT_SEQ_JWT_SECRET_KEY:-}
   frontend:
+    image: ghcr.io/ssciwr/circuit_seq_frontend:${CIRCUIT_SEQ_DOCKER_IMAGE_TAG:-latest}
     build: ./frontend
     ports:
       - 80:80

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,8 @@
-FROM node:16-slim as builder
+FROM node:18-slim as builder
+
+LABEL org.opencontainers.image.source=https://github.com/ssciwr/circuit_seq
+LABEL org.opencontainers.image.description="CircuitSEQ frontend production image"
+LABEL org.opencontainers.image.licenses=MIT
 
 WORKDIR /app
 


### PR DESCRIPTION
- add `CIRCUIT_SEQ_DOCKER_IMAGE_TAG` env var to docker-compose
  - if not set defaults to `latest`
- note: `VITE_REST_API_LOCATION` is set to production url for frontend container build
  - running this frontend container locally will make requests to the real server!
- for PRs:
  - just build docker images
- for commits to main branch:
  - build & tag images with the git SHA and push to container registry
  - build & tag images with `latest` and push to container registry
- resolves #14
