### PR TITLE
add date to backend logs

### DIFF
--- a/backend/src/circuit_seq_server/logger.py
+++ b/backend/src/circuit_seq_server/logger.py
@@ -9,7 +9,8 @@ def get_logger(name: str):
         handler = logging.StreamHandler()
         handler.setFormatter(
             logging.Formatter(
-                "%(name)s | [%(asctime)s %(levelname)s] %(message)s", "%H:%M:%S"
+                "%(name)s | [%(asctime)s %(levelname)s] %(message)s",
+                "%Y-%m-%d %H:%M:%S",
             )
         )
         logger.addHandler(handler)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -47,7 +47,7 @@ def result_zipfiles() -> List[pathlib.Path]:
     results_path = (
         pathlib.Path(os.path.dirname(os.path.abspath(__file__))) / "data" / "results"
     )
-    return list(results_path.glob("*.zip"))
+    return sorted(results_path.glob("*.zip"))
 
 
 @pytest.fixture()


### PR DESCRIPTION
- also sort result zip files used in tests by name
  - glob ordering is not defined
  - tests could fail if ran on different OS etc due to change in order of these files
