### PR TITLE
Add concentration field to samples

### DIFF
--- a/backend/src/circuit_seq_server/app.py
+++ b/backend/src/circuit_seq_server/app.py
@@ -231,12 +231,19 @@ def create_app(data_path: str = "/circuit_seq_data"):
     @jwt_required()
     def add_sample():
         email = current_user.email
-        name = request.form.to_dict().get("name", "")
-        running_option = request.form.to_dict().get("running_option", "")
+        form_as_dict = request.form.to_dict()
+        name = form_as_dict.get("name", "")
+        running_option = form_as_dict.get("running_option", "")
+        concentration = int(form_as_dict.get("concentration", "0"))
         reference_sequence_file = request.files.to_dict().get("file", None)
         logger.info(f"Adding sample {name} from {email}")
         new_sample, error_message = add_new_sample(
-            email, name, running_option, reference_sequence_file, data_path
+            email,
+            name,
+            running_option,
+            concentration,
+            reference_sequence_file,
+            data_path,
         )
         if new_sample is not None:
             logger.info(f"  - > success")

--- a/backend/src/circuit_seq_server/model.py
+++ b/backend/src/circuit_seq_server/model.py
@@ -86,13 +86,14 @@ class Sample(db.Model):
     primary_key: str = db.Column(db.String(32), nullable=False, unique=True)
     name: str = db.Column(db.String(128), nullable=False)
     running_option: str = db.Column(db.String(128), nullable=False)
+    concentration: int = db.Column(db.Integer, nullable=False)
     reference_sequence_description: Optional[str] = db.Column(
         db.String(256), nullable=True
     )
+    date: datetime.date = db.Column(db.Date, nullable=False)
     has_results_fasta: bool = db.Column(db.Boolean, nullable=False)
     has_results_gbk: bool = db.Column(db.Boolean, nullable=False)
     has_results_zip: bool = db.Column(db.Boolean, nullable=False)
-    date: datetime.date = db.Column(db.Date, nullable=False)
 
 
 def _samples_this_week(current_date: datetime.date):
@@ -144,6 +145,7 @@ def _write_samples_as_tsv_this_week(
             "email",
             "name",
             "running_option",
+            "concentration",
         ]
         writer.writerow(columns)
         for sample_tuple in current_samples:
@@ -386,6 +388,7 @@ def add_new_sample(
     email: str,
     name: str,
     running_option: str,
+    concentration: int,
     reference_sequence_file: Optional[FileStorage],
     data_path: str,
 ) -> Tuple[Optional[Sample], str]:
@@ -423,10 +426,11 @@ def add_new_sample(
                 return None, "Failed to parse reference sequence file."
     new_sample = Sample(
         email=email,
-        name=name,
         primary_key=key,
-        reference_sequence_description=reference_sequence_description,
+        name=name,
         running_option=running_option,
+        concentration=concentration,
+        reference_sequence_description=reference_sequence_description,
         date=today,
         has_results_zip=False,
         has_results_fasta=False,

--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -43,6 +43,7 @@ def add_test_samples(app):
                 primary_key=key,
                 reference_sequence_description=None,
                 running_option="running_option",
+                concentration=100 + 13 * n,
                 date=datetime.date.fromisocalendar(2022, week, n),
                 has_results_zip=False,
                 has_results_fasta=False,

--- a/backend/tests/test_model.py
+++ b/backend/tests/test_model.py
@@ -66,13 +66,14 @@ def test_add_new_sample_mon(app, tmp_path):
         assert model.remaining_samples_this_week(current_date)["remaining"] == 96
         # add a sample without a reference sequence
         new_sample, error_message = model.add_new_sample(
-            "u1@embl.de", "s1", "running option", None, str(tmp_path)
+            "u1@embl.de", "s1", "running option", 234, None, str(tmp_path)
         )
         assert error_message == ""
         assert new_sample is not None
         assert new_sample.email == "u1@embl.de"
         assert new_sample.name == "s1"
         assert new_sample.running_option == "running option"
+        assert new_sample.concentration == 234
         year, week, day = current_date.isocalendar()
         assert new_sample.primary_key == f"{year%100}_{week}_A1"
         assert new_sample.date == current_date
@@ -99,7 +100,7 @@ def test_add_new_sample_sat(app, tmp_path):
         )
         # try to add a sample on a saturday
         new_sample, error_message = model.add_new_sample(
-            "u1@embl.de", "s1", "running option", None, str(tmp_path)
+            "u1@embl.de", "s1", "running option", 123, None, str(tmp_path)
         )
         assert new_sample is None
         assert "closed" in error_message
@@ -117,7 +118,7 @@ def test_add_new_sample_sat(app, tmp_path):
         assert model.remaining_samples_this_week(current_date)["message"] == ""
         # try to add a sample on a saturday
         new_sample, error_message = model.add_new_sample(
-            "u1@embl.de", "s1", "running option", None, str(tmp_path)
+            "u1@embl.de", "s1", "running option", 123, None, str(tmp_path)
         )
         assert new_sample is not None
         assert error_message == ""
@@ -137,7 +138,7 @@ def test_add_new_sample_full(app, tmp_path):
         assert model._count_samples_this_week(current_date) == 0
         assert model.remaining_samples_this_week(current_date)["remaining"] == 1
         new_sample, error_message = model.add_new_sample(
-            "u1@embl.de", "s1", "running option", None, str(tmp_path)
+            "u1@embl.de", "s1", "running option", 11, None, str(tmp_path)
         )
         assert new_sample is not None
         assert error_message == ""
@@ -148,7 +149,7 @@ def test_add_new_sample_full(app, tmp_path):
             == "All samples have been taken this week."
         )
         new_sample, error_message = model.add_new_sample(
-            "u1@embl.de", "s2", "running option", None, str(tmp_path)
+            "u1@embl.de", "s2", "running option", 66, None, str(tmp_path)
         )
         assert new_sample is None
         assert "samples have been taken this week" in error_message

--- a/frontend/src/components/SamplesTable.vue
+++ b/frontend/src/components/SamplesTable.vue
@@ -16,6 +16,7 @@ defineProps<{
       <th>Primary Key</th>
       <th>Sample Name</th>
       <th>Running Option</th>
+      <th>Concentration</th>
       <th>Reference Sequence</th>
       <th>Results</th>
     </tr>
@@ -23,6 +24,7 @@ defineProps<{
       <td>{{ sample["primary_key"] }}</td>
       <td>{{ sample["name"] }}</td>
       <td>{{ sample["running_option"] }}</td>
+      <td>{{ sample["concentration"] }} ng/μl</td>
       <td>
         <template v-if="sample['reference_sequence_description']">
           <a

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -4,6 +4,7 @@ export type Sample = {
   name: string;
   email: string;
   running_option: string;
+  concentration: number;
   reference_sequence_description: string | null;
   date: string;
   has_results_zip: boolean;

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -24,7 +24,15 @@ apiClient
         samples.
       </p>
       <ul>
-        <li>Samples must be submitted by Wednesday each week.</li>
+        <li>Samples must be submitted by Wednesday each week</li>
+        <ul>
+          <li>via a letter box at H2.06.053.</li>
+          <li>in eppendorf 1.5 ml microtubes.</li>
+          <li>
+            with a concentration between 143 ng/μl (at least 7 μl sample) and
+            1000 ng/μl (at least 1 μl sample).
+          </li>
+        </ul>
         <li>Results will be available on Friday.</li>
         <template v-if="remaining_message">
           <li>{{ remaining_message }} Please try again on Monday.</li>

--- a/frontend/src/views/SamplesView.vue
+++ b/frontend/src/views/SamplesView.vue
@@ -6,6 +6,9 @@ import { apiClient } from "@/utils/api-client";
 import { validate_sample_name } from "@/utils/validation";
 import type { Sample, RunningOptions } from "@/utils/types";
 const new_sample_name = ref("");
+const new_sample_concentration = ref(200);
+const new_sample_concentration_min = ref(143);
+const new_sample_concentration_max = ref(1000);
 const selected_file = ref(null as null | Blob);
 const file_input_key = ref(0);
 const new_sample_error_message = ref("");
@@ -36,6 +39,18 @@ const new_sample_name_message = computed(() => {
     return "Sample name already used";
   } else if (!validate_sample_name(new_sample_name.value)) {
     return "Only alphanumeric characters and underscores allowed";
+  } else {
+    return "";
+  }
+});
+
+const new_sample_concentration_message = computed(() => {
+  if (new_sample_concentration.value < new_sample_concentration_min.value) {
+    return `Minimum sample concentration: ${new_sample_concentration_min.value} ng/μl`;
+  } else if (
+    new_sample_concentration.value > new_sample_concentration_max.value
+  ) {
+    return `Maximum sample concentration: ${new_sample_concentration_max.value} ng/μl`;
   } else {
     return "";
   }
@@ -89,6 +104,7 @@ function add_sample() {
   let formData = new FormData();
   formData.append("name", new_sample_name.value);
   formData.append("running_option", new_running_option.value);
+  formData.append("concentration", String(new_sample_concentration.value));
   if (selected_file.value !== null) {
     formData.append("file", selected_file.value);
   }
@@ -158,6 +174,22 @@ function add_sample() {
               </td>
             </tr>
             <tr>
+              <td style="text-align: right">Concentration (ng/μl):</td>
+              <td>
+                <input
+                  v-model="new_sample_concentration"
+                  type="number"
+                  :min="new_sample_concentration_min"
+                  :max="new_sample_concentration_max"
+                  placeholder="ng/μl"
+                  :title="new_sample_concentration_message"
+                />
+              </td>
+              <td style="font-style: italic">
+                {{ new_sample_concentration_message }}
+              </td>
+            </tr>
+            <tr>
               <td style="text-align: right">Reference sequence (optional):</td>
               <td>
                 <input
@@ -174,8 +206,16 @@ function add_sample() {
               <td>
                 <input
                   type="submit"
-                  :disabled="new_sample_name_message.length > 0"
-                  :title="new_sample_name_message"
+                  :disabled="
+                    new_sample_name_message.length +
+                      new_sample_concentration_message.length >
+                    0
+                  "
+                  :title="
+                    new_sample_name_message +
+                    '\n' +
+                    new_sample_concentration_message
+                  "
                 />
               </td>
             </tr>


### PR DESCRIPTION
- add new info on sample submission to front page
- add `concentration` integer field to Sample
- add it to `\sample` endpoint
- display it in the samples tables
- add it as input field when requesting samples
  - website enforces valid conc to be in range 143 < conc < 1000
- resolves #78
