### PR TITLE
Use nginx as reverse proxy for REST API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     name: "Docker"
     steps:
       - uses: actions/checkout@v3
-      - run: echo "VITE_REST_API_LOCATION=https://circuitseq.iwr.uni-heidelberg.de:8080" > frontend/.env
+      - run: echo "VITE_REST_API_LOCATION=https://circuitseq.iwr.uni-heidelberg.de/api" > frontend/.env
       - run: docker-compose build
       - uses: docker/login-action@v2
         with:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can sign up for a user account using any valid heidelberg/embl/dkfz email ad
 
 ## Notes
 
-- currently all uploaded samples and registered users may be deleted without warning as the prototype is updated!
+- currently all uploaded samples may be deleted without warning as the prototype is updated!
 
 ## Developer info
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,4 +10,4 @@ COPY . .
 
 RUN pip install .
 
-CMD ["gunicorn", "--certfile", "/circuit_seq_ssl_cert.pem", "--keyfile", "/circuit_seq_ssl_key.pem", "--bind", "0.0.0.0:8080", "circuit_seq_server:create_app()"]
+CMD ["gunicorn", "--bind", "backend:8080", "circuit_seq_server:create_app()"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -29,8 +29,6 @@ Options:
   --host TEXT       [default: localhost]
   --port INTEGER    [default: 8080]
   --data-path TEXT  [default: .]
-  --ssl-cert TEXT   [default: ./cert.pem]
-  --ssl-key TEXT    [default: ./key.pem]
   --help            Show this message and exit.
 ```
 

--- a/backend/src/circuit_seq_server/app.py
+++ b/backend/src/circuit_seq_server/app.py
@@ -70,7 +70,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
             db.select(User).filter(User.id == identity)
         ).scalar_one_or_none()
 
-    @app.route("/login", methods=["POST"])
+    @app.route("/api/login", methods=["POST"])
     def login():
         email = request.json.get("email", None)
         password = request.json.get("password", None)
@@ -91,7 +91,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
         access_token = create_access_token(identity=user)
         return jsonify(user=user.as_dict(), access_token=access_token)
 
-    @app.route("/signup", methods=["POST"])
+    @app.route("/api/signup", methods=["POST"])
     def signup():
         email = request.json.get("email", None)
         password = request.json.get("password", None)
@@ -99,12 +99,12 @@ def create_app(data_path: str = "/circuit_seq_data"):
         message, code = add_new_user(email, password, False)
         return jsonify(message=message), code
 
-    @app.route("/activate/<token>")
+    @app.route("/api/activate/<token>")
     def activate(token: str):
         message, code = activate_user(token)
         return jsonify(message=message), code
 
-    @app.route("/change_password", methods=["POST"])
+    @app.route("/api/change_password", methods=["POST"])
     @jwt_required()
     def change_password():
         current_password = request.json.get("current_password", None)
@@ -118,17 +118,17 @@ def create_app(data_path: str = "/circuit_seq_data"):
             return jsonify("Password changed.")
         return jsonify("Failed to change password: current password incorrect."), 401
 
-    @app.route("/remaining", methods=["GET"])
+    @app.route("/api/remaining", methods=["GET"])
     def remaining():
         return remaining_samples_this_week()
 
-    @app.route("/running_options", methods=["GET"])
+    @app.route("/api/running_options", methods=["GET"])
     @jwt_required()
     def running_options():
         settings = get_current_settings()
         return jsonify(running_options=settings["running_options"])
 
-    @app.route("/samples", methods=["GET"])
+    @app.route("/api/samples", methods=["GET"])
     @jwt_required()
     def samples():
         start_of_week = get_start_of_week()
@@ -156,7 +156,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
             current_samples=current_samples, previous_samples=previous_samples
         )
 
-    @app.route("/reference_sequence", methods=["POST"])
+    @app.route("/api/reference_sequence", methods=["POST"])
     @jwt_required()
     def reference_sequence():
         primary_key = request.json.get("primary_key", None)
@@ -189,7 +189,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
         logger.info(f"Returning fasta file {file}")
         return flask.send_file(file, as_attachment=True)
 
-    @app.route("/result", methods=["POST"])
+    @app.route("/api/result", methods=["POST"])
     @jwt_required()
     def result():
         primary_key = request.json.get("primary_key", None)
@@ -227,7 +227,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
         logger.info(f"Returning {filetype} file {file}")
         return flask.send_file(file, as_attachment=True)
 
-    @app.route("/sample", methods=["POST"])
+    @app.route("/api/sample", methods=["POST"])
     @jwt_required()
     def add_sample():
         email = current_user.email
@@ -250,7 +250,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
             return jsonify(sample=new_sample)
         return jsonify(message=error_message), 401
 
-    @app.route("/admin/settings", methods=["GET", "POST"])
+    @app.route("/api/admin/settings", methods=["GET", "POST"])
     @jwt_required()
     def admin_settings():
         if not current_user.is_admin:
@@ -261,7 +261,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
         else:
             return get_current_settings()
 
-    @app.route("/admin/samples", methods=["GET"])
+    @app.route("/api/admin/samples", methods=["GET"])
     @jwt_required()
     def admin_all_samples():
         if not current_user.is_admin:
@@ -290,7 +290,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
             current_samples=current_samples, previous_samples=previous_samples
         )
 
-    @app.route("/admin/zipsamples", methods=["POST"])
+    @app.route("/api/admin/zipsamples", methods=["POST"])
     @jwt_required()
     def admin_zip_samples():
         if not current_user.is_admin:
@@ -301,7 +301,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
         zip_file = update_samples_zipfile(data_path, datetime.date.today())
         return flask.send_file(zip_file, as_attachment=True)
 
-    @app.route("/admin/users", methods=["GET"])
+    @app.route("/api/admin/users", methods=["GET"])
     @jwt_required()
     def admin_users():
         if current_user.is_admin:
@@ -309,7 +309,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
             return jsonify(users=[user.as_dict() for user in users])
         return jsonify("Admin account required"), 401
 
-    @app.route("/admin/token", methods=["GET"])
+    @app.route("/api/admin/token", methods=["GET"])
     @jwt_required()
     def admin_token():
         if current_user.is_admin:
@@ -319,7 +319,7 @@ def create_app(data_path: str = "/circuit_seq_data"):
             return jsonify(access_token=access_token)
         return jsonify("Admin account required"), 401
 
-    @app.route("/admin/result", methods=["POST"])
+    @app.route("/api/admin/result", methods=["POST"])
     @jwt_required()
     def admin_upload_result():
         if not current_user.is_admin:

--- a/backend/src/circuit_seq_server/main.py
+++ b/backend/src/circuit_seq_server/main.py
@@ -7,11 +7,9 @@ from circuit_seq_server import create_app
 @click.option("--host", default="localhost", show_default=True)
 @click.option("--port", default=8080, show_default=True)
 @click.option("--data-path", default=".", show_default=True)
-@click.option("--ssl-cert", default="./cert.pem", show_default=True)
-@click.option("--ssl-key", default="./key.pem", show_default=True)
-def main(host: str, port: int, data_path: str, ssl_cert: str, ssl_key: str):
+def main(host: str, port: int, data_path: str):
     app = create_app(data_path=data_path)
-    app.run(host=host, port=port, ssl_context=(ssl_cert, ssl_key))
+    app.run(host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,8 @@ services:
   backend:
     image: ghcr.io/ssciwr/circuit_seq_backend:${CIRCUIT_SEQ_DOCKER_IMAGE_TAG:-latest}
     build: ./backend
-    ports:
-      - 8080:8080
     volumes:
       - ${CIRCUIT_SEQ_DATA:-./docker_volume}:/circuit_seq_data
-      - ${CIRCUIT_SEQ_SSL_CERT:-./cert.pem}:/circuit_seq_ssl_cert.pem
-      - ${CIRCUIT_SEQ_SSL_KEY:-./key.pem}:/circuit_seq_ssl_key.pem
     environment:
       - JWT_SECRET_KEY=${CIRCUIT_SEQ_JWT_SECRET_KEY:-}
   frontend:

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,1 +1,1 @@
-VITE_REST_API_LOCATION=https://localhost:8080
+VITE_REST_API_LOCATION=https://localhost/api

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -38,10 +38,17 @@ server {
 #         ssl_trusted_certificate /circuit_seq_ssl_cert.pem;
 #         resolver 1.1.1.1 1.0.0.1 [2606:4700:4700::1111] [2606:4700:4700::1001] valid=300s; # Cloudflare
 #         resolver_timeout 5s;
-
    location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         try_files $uri $uri/ /index.html;
+   }
+
+   location /api/ {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header Host $http_host;
+      proxy_redirect off;
+      proxy_pass http://backend:8080;
    }
 }

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -7,7 +7,6 @@ const remaining_message = ref("");
 apiClient
   .get("remaining")
   .then((response) => {
-    console.log(response);
     remaining.value = response.data.remaining;
     remaining_message.value = response.data.message;
   })

--- a/frontend/tests/e2e/home.cy.ts
+++ b/frontend/tests/e2e/home.cy.ts
@@ -3,7 +3,7 @@ describe("Home page", () => {
     cy.intercept(
       {
         method: "GET",
-        url: "/remaining",
+        url: "/api/remaining",
       },
       { remaining: 67 }
     );

--- a/notebooks/api_examples.ipynb
+++ b/notebooks/api_examples.ipynb
@@ -22,14 +22,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 19,
    "id": "5acb0ccb-2359-40f4-a2de-968cfc036cec",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "rest_api_url = \"https://circuitseq.iwr.uni-heidelberg.de:8080\""
+    "rest_api_url = \"https://circuitseq.iwr.uni-heidelberg.de/api\""
    ]
   },
   {
@@ -57,10 +57,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "id": "a3c8dd18-0a8d-4c1c-a5ca-0d30afee4109",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/lkeegan/.pyenv/versions/3.9.4/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "# requests is the standard Python library for this:\n",
     "response = requests.get(f\"{rest_api_url}/remaining\")"
@@ -68,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "id": "b1abefac-a700-4400-9687-2628396a23f2",
    "metadata": {},
    "outputs": [
@@ -78,7 +87,7 @@
        "200"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -90,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
    "id": "5dde50e9-2203-4595-a5fd-88930798b1c2",
    "metadata": {
     "tags": []
@@ -99,10 +108,10 @@
     {
      "data": {
       "text/plain": [
-       "{'message': '', 'remaining': 95}"
+       "{'message': '', 'remaining': 90}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -124,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "be92051d-7065-4816-b27a-194a181479b5",
    "metadata": {},
    "outputs": [],
@@ -135,42 +144,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "83c6b66c-ddd7-4ece-b8d5-94869cbcb880",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "401"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.status_code"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "cdba07ca-09df-49ed-bafe-d63361d898c8",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'msg': 'Missing Authorization Header'}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.json()"
    ]
@@ -191,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 14,
    "id": "8a8d2556-4b1b-4c4d-bfa6-e7f0786668fd",
    "metadata": {},
    "outputs": [],
@@ -216,27 +203,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 15,
    "id": "2b7a182a-fcb6-4c7d-b024-e432820e9e37",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/lkeegan/.pyenv/versions/3.9.4/lib/python3.9/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "response = requests.get(f\"{rest_api_url}/admin/samples\", headers=auth_header)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 16,
    "id": "7f35b3b3-31eb-4bd3-ade1-d2684a465980",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "422"
+       "200"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -247,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 17,
    "id": "8e2b19df-3d7c-488a-a268-774b72eff83a",
    "metadata": {},
    "outputs": [
@@ -257,7 +253,7 @@
        "dict_keys(['current_samples', 'previous_samples'])"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -268,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 18,
    "id": "ed81303f-5c08-47fa-9c02-4ca1c0486fa2",
    "metadata": {},
    "outputs": [
@@ -293,6 +289,7 @@
        "  <thead>\n",
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
+       "      <th>concentration</th>\n",
        "      <th>date</th>\n",
        "      <th>email</th>\n",
        "      <th>has_results_fasta</th>\n",
@@ -308,33 +305,127 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>Wed, 30 Nov 2022 00:00:00 GMT</td>\n",
+       "      <td>200</td>\n",
+       "      <td>Tue, 13 Dec 2022 00:00:00 GMT</td>\n",
        "      <td>liam.keegan@iwr.uni-heidelberg.de</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>False</td>\n",
        "      <td>1</td>\n",
-       "      <td>abc123</td>\n",
-       "      <td>22_48_A1</td>\n",
-       "      <td>Tet-pLKO-puro</td>\n",
-       "      <td>dna_r9.4.1_450bps_sup.cfg</td>\n",
+       "      <td>asd</td>\n",
+       "      <td>22_50_A1</td>\n",
+       "      <td>None</td>\n",
+       "      <td>afsadf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>999</td>\n",
+       "      <td>Tue, 13 Dec 2022 00:00:00 GMT</td>\n",
+       "      <td>liam.keegan@iwr.uni-heidelberg.de</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>2</td>\n",
+       "      <td>234</td>\n",
+       "      <td>22_50_A2</td>\n",
+       "      <td>Reference</td>\n",
+       "      <td>afsadf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>800</td>\n",
+       "      <td>Tue, 13 Dec 2022 00:00:00 GMT</td>\n",
+       "      <td>liam.keegan@iwr.uni-heidelberg.de</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>3</td>\n",
+       "      <td>sgsdf</td>\n",
+       "      <td>22_50_A3</td>\n",
+       "      <td>None</td>\n",
+       "      <td>afsadf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>200</td>\n",
+       "      <td>Tue, 13 Dec 2022 00:00:00 GMT</td>\n",
+       "      <td>liam.keegan@iwr.uni-heidelberg.de</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>4</td>\n",
+       "      <td>sdfsdf</td>\n",
+       "      <td>22_50_A4</td>\n",
+       "      <td>None</td>\n",
+       "      <td>afsadf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>202</td>\n",
+       "      <td>Tue, 13 Dec 2022 00:00:00 GMT</td>\n",
+       "      <td>liam.keegan@iwr.uni-heidelberg.de</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>5</td>\n",
+       "      <td>fddf</td>\n",
+       "      <td>22_50_A5</td>\n",
+       "      <td>None</td>\n",
+       "      <td>afsadf</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>666</td>\n",
+       "      <td>Tue, 13 Dec 2022 00:00:00 GMT</td>\n",
+       "      <td>liam.keegan@iwr.uni-heidelberg.de</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>False</td>\n",
+       "      <td>6</td>\n",
+       "      <td>adsfsdf</td>\n",
+       "      <td>22_50_A6</td>\n",
+       "      <td>Reference</td>\n",
+       "      <td>sdfwfwe</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                            date                              email  \\\n",
-       "0  Wed, 30 Nov 2022 00:00:00 GMT  liam.keegan@iwr.uni-heidelberg.de   \n",
+       "   concentration                           date  \\\n",
+       "0            200  Tue, 13 Dec 2022 00:00:00 GMT   \n",
+       "1            999  Tue, 13 Dec 2022 00:00:00 GMT   \n",
+       "2            800  Tue, 13 Dec 2022 00:00:00 GMT   \n",
+       "3            200  Tue, 13 Dec 2022 00:00:00 GMT   \n",
+       "4            202  Tue, 13 Dec 2022 00:00:00 GMT   \n",
+       "5            666  Tue, 13 Dec 2022 00:00:00 GMT   \n",
        "\n",
-       "   has_results_fasta  has_results_gbk  has_results_zip  id    name  \\\n",
-       "0              False            False            False   1  abc123   \n",
+       "                               email  has_results_fasta  has_results_gbk  \\\n",
+       "0  liam.keegan@iwr.uni-heidelberg.de              False            False   \n",
+       "1  liam.keegan@iwr.uni-heidelberg.de              False            False   \n",
+       "2  liam.keegan@iwr.uni-heidelberg.de              False            False   \n",
+       "3  liam.keegan@iwr.uni-heidelberg.de              False            False   \n",
+       "4  liam.keegan@iwr.uni-heidelberg.de              False            False   \n",
+       "5  liam.keegan@iwr.uni-heidelberg.de              False            False   \n",
        "\n",
-       "  primary_key reference_sequence_description             running_option  \n",
-       "0    22_48_A1                  Tet-pLKO-puro  dna_r9.4.1_450bps_sup.cfg  "
+       "   has_results_zip  id     name primary_key reference_sequence_description  \\\n",
+       "0            False   1      asd    22_50_A1                           None   \n",
+       "1            False   2      234    22_50_A2                      Reference   \n",
+       "2            False   3    sgsdf    22_50_A3                           None   \n",
+       "3            False   4   sdfsdf    22_50_A4                           None   \n",
+       "4            False   5     fddf    22_50_A5                           None   \n",
+       "5            False   6  adsfsdf    22_50_A6                      Reference   \n",
+       "\n",
+       "  running_option  \n",
+       "0         afsadf  \n",
+       "1         afsadf  \n",
+       "2         afsadf  \n",
+       "3         afsadf  \n",
+       "4         afsadf  \n",
+       "5        sdfwfwe  "
       ]
      },
-     "execution_count": 25,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -357,7 +448,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "c0181862-392f-467b-b29e-1d6297fe2865",
    "metadata": {},
    "outputs": [],
@@ -367,28 +458,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "b19628ef-ed00-4df0-8e3c-9dda4aeb949d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "200"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.status_code"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "a081472f-c287-4fae-a065-27dd12499bcf",
    "metadata": {},
    "outputs": [],
@@ -414,7 +494,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "eaf9a407-de31-4514-9900-edf6593fdfb6",
    "metadata": {},
    "outputs": [],
@@ -429,42 +509,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "3e39d57a-b08b-438d-bd92-a9d9c90970da",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "401"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.status_code"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "c5801429-df35-4f82-9ee9-d407e28149a1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'message': 'Unknown primary key 22_46_A2'}"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.json()"
    ]
@@ -486,7 +544,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- REST API is now located at `https://circuitseq.iwr.uni-heidelberg.de/api`
- https calls to /api/* are forwarded by nginx to the flask server
- frontend `VITE_REST_API_LOCATION`
  - in Docker
    - production: `https://circuitseq.iwr.uni-heidelberg.de/api`
    - default: `https://localhost/api`
  - dev
    - `https://localhost/api`
- backend
  - remove all SSL config, revert to plain http
  - in Docker
    - gunicorn binds to http://backend:8080
    - this is only visible to other docker containers in the same network
    - not exposed outside of docker
  - in development environment
    - dev server on localhost:8080
  - all endpoints are now prefixed with `/api/`
- update notebook with new REST API url
- resolves #40
