### PR TITLE
allow unsucessful result upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,53 @@
-# CircuitSEQ website prototype
+# CircuitSEQ website
 
 [![CI](https://github.com/ssciwr/circuit_seq/actions/workflows/ci.yml/badge.svg)](https://github.com/ssciwr/circuit_seq/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/ssciwr/circuit_seq/branch/main/graph/badge.svg?token=Z8fyKbjrHd)](https://codecov.io/gh/ssciwr/circuit_seq)
 
-A work-in-progress prototype of the CircuitSEQ website.
-
-## Try it out online
-
-It is now running on a heiCLOUD VM here: https://circuitseq.iwr.uni-heidelberg.de/
-
-You can sign up for a user account using any valid heidelberg/embl/dkfz email address.
+The source code for the [CircuitSEQ website](https://circuitseq.iwr.uni-heidelberg.de/).
 
 ## Implemented features
 
-- Users can
-  - sign up with a valid email address
-  - request a sample, optionally providing a reference sequence
-  - see a list of their requested samples
-  - download their reference sequences
-  - download their results
-- Admins can
-  - see a list of all users
-  - see a list of all requested samples
-  - change the site settings
-    - set which day of the week sample submission closes
-    - set number of plate rows/cols
-    - add/remove running options
-  - download a zipped tsv of this weeks requests including reference sequences as fasta files
-  - upload a zipfile with analysis results for a sample
-  - also do all of the above using a REST API (see [api_examples.ipynb](https://github.com/ssciwr/circuit_seq/blob/main/notebooks/api_examples.ipynb))
+### Users
 
-## Notes
+Users of the site can
 
-- currently all uploaded samples may be deleted without warning as the prototype is updated!
+- sign up with a valid email address
+- request a sample, optionally providing a reference sequence
+- see a list of their requested samples
+- download their reference sequences
+- download full analysis data
+- automatically receive an email with their results
+
+### Admins
+
+Users with admin rights can additionally
+
+- see a list of all users
+- see a list of all requested samples and results
+- change the site settings
+  - set which day of the week sample submission closes
+  - set number of plate rows/cols
+  - add/remove running options
+- download a zipped tsv of requests from the current week
+  - this includes the reference sequences as fasta files
+- upload a zipfile with successful analysis results to be sent to the user
+- upload unsuccessful analysis result status to be sent to the user
+
+### REST API
+
+Admins can also generate an API token,
+then do all of the above programatically using
+the provided REST API:
+
+- [api_examples.ipynb](https://github.com/ssciwr/circuit_seq/blob/main/notebooks/api_examples.ipynb))
 
 ## Developer info
 
-If you want to make changes to the code, see [README_DEV.md](README_DEV.md) for instructions on how to locally build and deploy the website.
+If you want to make changes to the code, see
+[README_DEV.md](README_DEV.md)
+for instructions on how to locally build make a test deployment of the website.
+
+## Deployment info
+
+For information on how to deploy the website see
+[README_DEPLOYMENT.md](README_DEPLOYMENT.md).

--- a/README_DEPLOYMENT.md
+++ b/README_DEPLOYMENT.md
@@ -1,0 +1,55 @@
+# CircuitSEQ website deployment info
+
+Some information on how to deploy the website - currently it is deployed on a heicloud VM.
+
+## Production deployment
+
+Production docker container images are automatically built by CI.
+To deploy the latest version on a virtual machine with docker-compose installed,
+download [https://raw.githubusercontent.com/ssciwr/circuit_seq/main/docker-compose.yml](docker-compose.yml), then do
+
+```
+sudo docker-compose pull
+sudo docker-compose up -d
+```
+
+The location of data directory, SSL keys and secret key should be set
+either in env vars or in a file `.env` in the same location as the docker-compose.yml.
+
+For example the current deployment on heicloud looks like this:
+
+```
+CIRCUIT_SEQ_DATA="/home/ubuntu/circuit_seq/docker_volume"
+CIRCUIT_SEQ_SSL_CERT="/etc/letsencrypt/live/circuitseq.iwr.uni-heidelberg.de/fullchain.pem"
+CIRCUIT_SEQ_SSL_KEY="/etc/letsencrypt/live/circuitseq.iwr.uni-heidelberg.de/privkey.pem"
+CIRCUIT_SEQ_JWT_SECRET_KEY="abc123" # to generate a new secret key: `python -c "import secrets; print(secrets.token_urlsafe(64))"`
+```
+
+The current status of the containers can be checked with
+
+```
+sudo docker-compose ps
+sudo docker-compose logs
+```
+
+### Renew SSL certificate
+
+Certbot attempts to auto-renew but this requires port 80, which is already taken by our web server.
+To update the certificate manually:
+
+```
+sudo docker-compose down
+sudo certbot renew
+sudo docker-compose up -d
+```
+
+### Give users admin rights
+
+To make an existing user with email `user@embl.de` into an admin, ssh into the VM, then
+
+```
+cd circuit_seq
+sudo sqlite3 docker_volume/CircuitSeq.db
+sqlite> UPDATE user SET is_admin=true WHERE email='user@embl.de';
+sqlite> .quit
+```

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -4,7 +4,12 @@ Some information on how to locally build and deploy the website if you would lik
 
 ## Run locally with docker-compose
 
-To run the website locally in docker containers on your computer (on linux, with docker-compose installed):
+Pre-requisites:
+
+- docker and docker-compose
+- you have created an SSL cert/key pair as described below
+
+To run the website locally in docker containers on your computer:
 
 ```sh
 git clone https://github.com/ssciwr/circuit_seq.git
@@ -24,7 +29,7 @@ SSL cert/key by default are assumed to exist as `cert.pem` and `key.pem`
 in the folder where you run the docker-compose command.
 To point to different files, set the `CIRCUIT_SEQ_SSL_CERT` and `CIRCUIT_SEQ_SSL_KEY` environment variables.
 
-To generate a cert/key pair:
+For example to generate a cert/key pair on linux:
 
 ```
 openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -sha256 -days 365 -nodes -subj '/CN=localhost'
@@ -44,7 +49,8 @@ Note that the SSK keys are self-signed keys and your browser will still warn abo
 ### User signup activation email
 
 When you sign up for an account when running locally it will send an email (if port 25 is open) to whatever address you use.
-If the port is blocked you can see the activation_token in the docker logs, and activate your local account by going to https://localhost/activate/activation_token_from_logs
+If the port is blocked you can see the activation_token in the docker logs,
+and activate your local account by going to `https://localhost/activate/<activation_token_from_logs>`
 To make yourself an admin user, see the production deployment section below.
 
 ## Run locally with Python and npm
@@ -73,7 +79,8 @@ npm install
 npm run dev
 ```
 
-The website is then served at http://localhost:5173/
+The website is then served at http://localhost:5173/.
+Note that email activation will not work without the postfix docker image.
 
 ## Implementation
 
@@ -87,53 +94,5 @@ The frontend is a vue.js app, see [frontend/README.md](frontend/README.md) for m
 
 ### Docker
 
-Both the backend and the frontend have a Dockerfile, and there is docker-compose file to coordinate them.
-
-## Production deployment
-
-Same as docker-compose but instead of building from source there are also public production containers
-built by CI that can be pulled, so all that is needed to deploy the latest version is to download the docker-compose.yml file, then
-
-```
-sudo docker-compose pull
-sudo docker-compose up -d
-```
-
-The location of data directory, SSL keys and secret key should be set
-either in env vars or in a file `.env` in the same location as the docker-compose.yml, e.g.:
-
-```
-CIRCUIT_SEQ_DATA="/home/ubuntu/circuit_seq/docker_volume"
-CIRCUIT_SEQ_SSL_CERT="/etc/letsencrypt/live/circuitseq.iwr.uni-heidelberg.de/fullchain.pem"
-CIRCUIT_SEQ_SSL_KEY="/etc/letsencrypt/live/circuitseq.iwr.uni-heidelberg.de/privkey.pem"
-CIRCUIT_SEQ_JWT_SECRET_KEY="abc123" # to generate a new secret key: `python -c "import secrets; print(secrets.token_urlsafe(64))"`
-```
-
-The current status of the containers can be checked with
-
-```
-sudo docker-compose ps
-sudo docker-compose logs
-```
-
-### Renew SSL certificate
-
-Certbot attempts to auto-renew but this requires port 80, which is already taken by our web server.
-To update the certificate manually:
-
-```
-sudo docker-compose down
-sudo certbot renew
-sudo docker-compose up -d
-```
-
-### Give users admin rights
-
-To make an existing user with email `user@embl.de` into an admin, ssh into the VM, then
-
-```
-cd circuit_seq
-sudo sqlite3 docker_volume/CircuitSeq.db
-sqlite> UPDATE user SET is_admin=true WHERE email='user@embl.de';
-sqlite> .quit
-```
+Both the backend and the frontend have a Dockerfile,
+and there is a docker-compose file to coordinate them.

--- a/backend/tests/helpers/flask_test_utils.py
+++ b/backend/tests/helpers/flask_test_utils.py
@@ -1,11 +1,9 @@
-from flask_sqlalchemy import SQLAlchemy
 import argon2
-from circuit_seq_server.model import User, Sample
+from circuit_seq_server.model import User, Sample, db
 import datetime
 
 
 def add_test_users(app):
-    db = SQLAlchemy(app)
     ph = argon2.PasswordHasher()
     with app.app_context():
         # add users for tests
@@ -23,7 +21,6 @@ def add_test_users(app):
 
 
 def add_test_samples(app):
-    db = SQLAlchemy(app)
     with app.app_context():
         # add samples for tests
         week = 46

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -347,12 +347,15 @@ def test_result_invalid(client):
         assert f"No {filetype} results available" in response.json
 
 
-def _upload_result(client, result_zipfile):
+def _upload_result(client, result_zipfile: pathlib.Path):
     headers = _get_auth_headers(client, "admin@embl.de", "admin")
+    primary_key = result_zipfile.stem[0:8]
     with open(result_zipfile, "rb") as f:
         response = client.post(
             "/api/admin/result",
             data={
+                "primary_key": primary_key,
+                "success": True,
                 "file": (io.BytesIO(f.read()), result_zipfile.name),
             },
             headers=headers,
@@ -363,7 +366,7 @@ def _upload_result(client, result_zipfile):
 def test_result_valid(client, result_zipfiles):
     headers = _get_auth_headers(client, "user@embl.de", "user")
     key = "22_46_A2"
-    _upload_result(client, result_zipfiles[0])
+    assert _upload_result(client, result_zipfiles[0]).status_code == 200
     for filetype in ["fasta", "gbk", "zip"]:
         response = client.post(
             "/api/result",

--- a/frontend/src/components/SamplesTable.vue
+++ b/frontend/src/components/SamplesTable.vue
@@ -7,6 +7,7 @@ import type { Sample } from "@/utils/types";
 
 defineProps<{
   samples: Sample[];
+  show_email: boolean;
 }>();
 </script>
 
@@ -14,6 +15,7 @@ defineProps<{
   <table class="zebra">
     <tr>
       <th>Primary Key</th>
+      <th v-if="show_email">Email</th>
       <th>Sample Name</th>
       <th>Running Option</th>
       <th>Concentration</th>
@@ -22,6 +24,7 @@ defineProps<{
     </tr>
     <tr v-for="sample in samples" :key="sample.id">
       <td>{{ sample["primary_key"] }}</td>
+      <td v-if="show_email">{{ sample["email"] }}</td>
       <td>{{ sample["name"] }}</td>
       <td>{{ sample["running_option"] }}</td>
       <td>{{ sample["concentration"] }} ng/μl</td>

--- a/frontend/src/views/AboutView.vue
+++ b/frontend/src/views/AboutView.vue
@@ -46,11 +46,21 @@ apiClient
       <a href="mailto:e.green@dkfz.de?subject=circuitSEQ">e.green@dkfz.de</a>
     </ListItem>
     <ListItem title="References" icon="bi-book">
-      This software implements a variant of the Circuit-seq method published by
-      the McKenna lab:
-      <a href="https://pubs.acs.org/doi/pdf/10.1021/acssynbio.2c00126"
-        >ACS Synth. Biol. 2022, 11, 2238−2246</a
-      >
+      <p>
+        This software implements a variant of the Circuit-seq method published
+        by the McKenna lab:
+        <a href="https://pubs.acs.org/doi/pdf/10.1021/acssynbio.2c00126"
+          >ACS Synth. Biol. 2022, 11, 2238−2246</a
+        >.
+      </p>
+      <p>
+        The <a href="https://github.com/ssciwr/circuit_seq">web service</a> was
+        developed by the
+        <a href="https://ssc.iwr.uni-heidelberg.de/"
+          >Scientific Software Center</a
+        >
+        of Heidelberg University.
+      </p>
     </ListItem>
     <ListItem title="Funding" icon="bi-info-circle">
       This work was funded by the

--- a/frontend/src/views/SamplesView.vue
+++ b/frontend/src/views/SamplesView.vue
@@ -133,7 +133,10 @@ function add_sample() {
     <ListItem title="My samples" icon="bi-clipboard-data">
       <template v-if="current_samples.length > 0">
         <p>Your samples for this week:</p>
-        <SamplesTable :samples="current_samples"></SamplesTable>
+        <SamplesTable
+          :samples="current_samples"
+          :show_email="false"
+        ></SamplesTable>
       </template>
       <template v-else>
         <p>You don't have any samples this week.</p>
@@ -245,7 +248,10 @@ function add_sample() {
     <ListItem title="Results" icon="bi-clipboard-data">
       <template v-if="previous_samples.length > 0">
         <p>Results from your previous samples:</p>
-        <SamplesTable :samples="previous_samples"></SamplesTable>
+        <SamplesTable
+          :samples="previous_samples"
+          :show_email="false"
+        ></SamplesTable>
       </template>
       <template v-else>
         <p>No previous samples.</p>

--- a/notebooks/api_examples.ipynb
+++ b/notebooks/api_examples.ipynb
@@ -99,7 +99,7 @@
     {
      "data": {
       "text/plain": [
-       "{'message': '', 'remaining': 95}"
+       "{'message': '', 'remaining': 96}"
       ]
      },
      "execution_count": 5,
@@ -216,7 +216,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "2b7a182a-fcb6-4c7d-b024-e432820e9e37",
    "metadata": {},
    "outputs": [],
@@ -226,124 +226,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "7f35b3b3-31eb-4bd3-ade1-d2684a465980",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "200"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.status_code"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "id": "8e2b19df-3d7c-488a-a268-774b72eff83a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['current_samples', 'previous_samples'])"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.json().keys()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "ed81303f-5c08-47fa-9c02-4ca1c0486fa2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>concentration</th>\n",
-       "      <th>date</th>\n",
-       "      <th>email</th>\n",
-       "      <th>has_results_fasta</th>\n",
-       "      <th>has_results_gbk</th>\n",
-       "      <th>has_results_zip</th>\n",
-       "      <th>id</th>\n",
-       "      <th>name</th>\n",
-       "      <th>primary_key</th>\n",
-       "      <th>reference_sequence_description</th>\n",
-       "      <th>running_option</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>456</td>\n",
-       "      <td>Tue, 13 Dec 2022 00:00:00 GMT</td>\n",
-       "      <td>liam.keegan@iwr.uni-heidelberg.de</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>False</td>\n",
-       "      <td>1</td>\n",
-       "      <td>test_concentration</td>\n",
-       "      <td>22_50_A1</td>\n",
-       "      <td>Reference</td>\n",
-       "      <td></td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   concentration                           date  \\\n",
-       "0            456  Tue, 13 Dec 2022 00:00:00 GMT   \n",
-       "\n",
-       "                               email  has_results_fasta  has_results_gbk  \\\n",
-       "0  liam.keegan@iwr.uni-heidelberg.de              False            False   \n",
-       "\n",
-       "   has_results_zip  id                name primary_key  \\\n",
-       "0            False   1  test_concentration    22_50_A1   \n",
-       "\n",
-       "  reference_sequence_description running_option  \n",
-       "0                      Reference                 "
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pd.DataFrame(response.json()[\"current_samples\"])"
    ]
@@ -362,7 +268,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "c0181862-392f-467b-b29e-1d6297fe2865",
    "metadata": {},
    "outputs": [],
@@ -372,28 +278,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "id": "b19628ef-ed00-4df0-8e3c-9dda4aeb949d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "200"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.status_code"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "a081472f-c287-4fae-a065-27dd12499bcf",
    "metadata": {},
    "outputs": [],
@@ -412,67 +307,128 @@
    "source": [
     "### `/admin/result`\n",
     "\n",
-    "- upload a zipfile of results for a sample\n",
-    "- assumes the zipfile is named `[PRIMARY_KEY]_[NAME].zip`\n",
-    "- on success returns the path on the server where the zipfile is stored"
+    "- upload success or failure status for results of sample analysis"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ed36b3d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Upload a successful result\n",
+    "\n",
+    "- you need to provide\n",
+    "  - `primary_key`: the primary key of the sample\n",
+    "  - `file`: the zipfile of results with name `[PRIMARY_KEY]_[NAME].zip`\n",
+    "  - `success=\"true\"`: success status of analysis\n",
+    "- zip file structure: must contain these files\n",
+    "  - `[PRIMARY_KEY]_[NAME].fasta`\n",
+    "  - `[PRIMARY_KEY]_[NAME].gbk`\n",
+    "- on success returns the path on the server where the zipfile is stored\n",
+    "  - the user will also receive an email with fasta/gbk results attached\n",
+    "- on failure a diagnostic message will be returned"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "eaf9a407-de31-4514-9900-edf6593fdfb6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(\n",
-    "    \"../backend/tests/data/results/22_46_A2_ZIP_TEST_pMC_Final_Kan.zip\", \"rb\"\n",
-    ") as f:\n",
+    "with open(\"22_01_A1_sample.zip\", \"rb\") as f:\n",
     "    response = requests.post(\n",
-    "        f\"{rest_api_url}/admin/result\", files={\"file\": f}, headers=auth_header\n",
+    "        f\"{rest_api_url}/admin/result\",\n",
+    "        data={\"primary_key\": \"22_01_A1\", \"success\": \"true\"},\n",
+    "        files={\"file\": f},\n",
+    "        headers=auth_header,\n",
     "    )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "3e39d57a-b08b-438d-bd92-a9d9c90970da",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "401"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "response.status_code"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "c5801429-df35-4f82-9ee9-d407e28149a1",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'message': 'Unknown primary key 22_46_A2'}"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "response.json()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "594ca768",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Upload an unsuccessful result\n",
+    "\n",
+    "- you need to provide\n",
+    "  - `primary_key`: the primary key of the sample\n",
+    "  - `success=\"false\"`: success status of analysis\n",
+    "- zip file not required\n",
+    "- if the primary key is valid the user will receive an email with the unsuccessful analysis status\n",
+    "- otherwise a diagnostic message will be returned"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d661927",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.post(\n",
+    "    f\"{rest_api_url}/admin/result\",\n",
+    "    data={\"primary_key\": \"22_01_A1\", \"success\": \"false\"},\n",
+    "    headers=auth_header,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cb9e77b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response.status_code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b2f3055",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "response.json()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "933b9713",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -491,7 +447,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- `/admin/result` now takes `primary_key` and `success` parameters as well as the zip file
  - if `success` is `False`, sends email to user saying sample processed but no results
  - if `True`, processes zipfile and sends email to user with results attached as before
- resolves #82

stricter validation of uploaded result zipfile

- returns error if
  - zipfile name doesn't start with primary key [KEY]
  - zipfile doesn't contain [KEY]_[LABEL].fasta
  - zipfile doesn't contain [KEY]_[LABEL].gbk
- hopefully reduces the possibility of emailing empty/incorrect results to user
- resolves #94

also

- add results_dir() and result_file_path() methods to Sample
  - they get the data_path from the flask current app config
  - no need to explicitly pass data_path from app to model methods
- refactor common code from `/samples` and `/admin/samples` into `model.get_samples()`
- update README, add README_DEPLOYMENT
- add link to SSC & website source code to About/References web page