### PR TITLE
Add password reset option

### DIFF
--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 from circuit_seq_server.utils import get_primary_key
 import datetime
 from circuit_seq_server.utils import get_start_of_week
+from circuit_seq_server.utils import (
+    encode_password_reset_token,
+    decode_password_reset_token,
+)
+from circuit_seq_server.utils import encode_activation_token, decode_activation_token
 
 
 def test_get_start_of_week():
@@ -38,3 +43,27 @@ def test_primary_key_8_12():
     assert get_primary_key(year, 1, 1, rows, cols) == "22_01_A2"
     assert get_primary_key(year, 1, 95, rows, cols) == "22_01_H12"
     assert get_primary_key(year, 1, 96, rows, cols) is None
+
+
+def test_password_reset_token():
+    email = "asdfads@dasfgdasf.com"
+    secret = "p23c5fn78nd"
+    token = encode_password_reset_token(email, secret)
+    decoded_email = decode_password_reset_token(token, secret)
+    assert decoded_email == email
+    decoded_email = decode_password_reset_token(token, "wrong secret")
+    assert decoded_email is None
+    decoded_email = decode_password_reset_token("invalid-token", secret)
+    assert decoded_email is None
+
+
+def test_activation_token():
+    email = "asdfads@dasfgdasf.com"
+    secret = "p23c5fn78nd"
+    token = encode_activation_token(email, secret)
+    decoded_email = decode_activation_token(token, secret)
+    assert decoded_email == email
+    decoded_email = decode_activation_token(token, "wrong secret")
+    assert decoded_email is None
+    decoded_email = decode_activation_token("invalid-token", secret)
+    assert decoded_email is None

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/frontend/src/components/AccountComponent.vue
+++ b/frontend/src/components/AccountComponent.vue
@@ -64,20 +64,20 @@ function do_change_password() {
   <ListItem title="Change password" icon="bi-key">
     <form @submit.prevent="do_change_password">
       <p>
-        <label for="passwd_old">Current Password:</label>
+        <label for="account_passwd_old">Current Password:</label>
         <input
           v-model="current_password"
-          id="passwd_old"
+          id="account_passwd_old"
           type="password"
           placeholder="current password"
           maxlength="256"
         />
       </p>
       <p>
-        <label for="passwd_new">New Password:</label>
+        <label for="account_passwd_new">New Password:</label>
         <input
           v-model="new_password"
-          id="passwd_new"
+          id="account_passwd_new"
           type="password"
           placeholder="new password"
           :title="new_password_message"
@@ -86,10 +86,10 @@ function do_change_password() {
         <span class="error-message pad-left">{{ new_password_message }}</span>
       </p>
       <p>
-        <label for="passwd_new2">Confirm New Password:</label>
+        <label for="account_passwd_new2">Confirm New Password:</label>
         <input
           v-model="new_password2"
-          id="passwd_new2"
+          id="account_passwd_new2"
           type="password"
           placeholder="new password"
           :title="new_password2_message"

--- a/frontend/src/components/LoginComponent.vue
+++ b/frontend/src/components/LoginComponent.vue
@@ -32,19 +32,19 @@ function do_login() {
     <p>Log in with the email address and password you used to sign up:</p>
     <form @submit.prevent="do_login">
       <p>
-        <label for="email">Email:</label>
+        <label for="login_email">Email:</label>
         <input
           v-model="login_email_address"
-          id="email"
+          id="login_email"
           placeholder="your.name@uni-heidelberg.de"
           maxlength="256"
         />
       </p>
       <p>
-        <label for="password">Password:</label>
+        <label for="login_password">Password:</label>
         <input
           v-model="login_password"
-          id="password"
+          id="login_password"
           type="password"
           maxlength="256"
         />

--- a/frontend/src/components/ResetComponent.vue
+++ b/frontend/src/components/ResetComponent.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { ref } from "vue";
+import { apiClient } from "@/utils/api-client";
+import ListItem from "@/components/ListItem.vue";
+const reset_email_address = ref("");
+const reset_message = ref("");
+function do_reset() {
+  apiClient
+    .post("request_password_reset", {
+      email: reset_email_address.value,
+    })
+    .then((response) => {
+      reset_message.value = response.data.message;
+    })
+    .catch((error) => {
+      reset_message.value = `${error.response.data.message}`;
+    });
+}
+</script>
+
+<template>
+  <ListItem title="Reset password" icon="bi-person">
+    <p>
+      If you have forgotten your password you can request a password reset email
+      by entering the email address you used to sign up:
+    </p>
+    <form @submit.prevent="do_reset">
+      <p>
+        <label for="reset_email">Email:</label>
+        <input
+          v-model="reset_email_address"
+          id="reset_email"
+          placeholder="your.name@uni-heidelberg.de"
+          maxlength="256"
+        />
+      </p>
+      <p>
+        <input type="submit" />
+        <span class="error-message pad-left">
+          {{ reset_message }}
+        </span>
+      </p>
+    </form>
+  </ListItem>
+</template>

--- a/frontend/src/components/SignupComponent.vue
+++ b/frontend/src/components/SignupComponent.vue
@@ -44,10 +44,10 @@ function do_signup() {
     </p>
     <form @submit.prevent="do_signup">
       <div>
-        <label for="email">Email:</label>
+        <label for="signup_email">Email:</label>
         <input
           v-model="signup_email_address"
-          id="email"
+          id="signup_email"
           placeholder="your.name@uni-heidelberg.de"
           :title="signup_email_address_message"
           maxlength="256"
@@ -57,10 +57,10 @@ function do_signup() {
         }}</span>
       </div>
       <p>
-        <label for="password">Password:</label>
+        <label for="signup_password">Password:</label>
         <input
           v-model="signup_password"
-          id="password"
+          id="signup_password"
           type="password"
           placeholder="password"
           :title="signup_password_message"

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -22,6 +22,12 @@ const router = createRouter({
       props: true,
     },
     {
+      path: "/reset_password/:reset_token",
+      name: "reset_password",
+      component: () => import("../views/ResetPasswordView.vue"),
+      props: true,
+    },
+    {
       path: "/samples",
       name: "samples",
       component: () => import("../views/SamplesView.vue"),

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -3,6 +3,7 @@ import { useUserStore } from "@/stores/user";
 import LoginComponent from "@/components/LoginComponent.vue";
 import SignupComponent from "@/components/SignupComponent.vue";
 import AccountComponent from "@/components/AccountComponent.vue";
+import ResetComponent from "@/components/ResetComponent.vue";
 const userStore = useUserStore();
 </script>
 
@@ -14,6 +15,7 @@ const userStore = useUserStore();
     <template v-else>
       <LoginComponent></LoginComponent>
       <SignupComponent></SignupComponent>
+      <ResetComponent></ResetComponent>
     </template>
   </main>
 </template>

--- a/frontend/src/views/ResetPasswordView.vue
+++ b/frontend/src/views/ResetPasswordView.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+import ListItem from "@/components/ListItem.vue";
+import { ref, computed } from "vue";
+import { apiClient } from "@/utils/api-client";
+import { validate_password } from "@/utils/validation";
+const props = defineProps({ reset_token: String });
+
+const title = ref("Reset password");
+const message = ref("");
+const icon = ref("bi-key");
+const show_form = ref(true);
+
+const email = ref("");
+const new_password = ref("");
+const new_password_message = computed(() => {
+  if (
+    new_password.value.length === 0 ||
+    validate_password(new_password.value)
+  ) {
+    return "";
+  } else {
+    return "At least 8 characters, including lower-case, upper-case and a number.";
+  }
+});
+const new_password2 = ref("");
+const new_password2_message = computed(() => {
+  if (new_password.value == new_password2.value) {
+    return "";
+  } else {
+    return "New passwords don't match";
+  }
+});
+
+function reset_password() {
+  apiClient
+    .post("reset_password", {
+      reset_token: props.reset_token,
+      email: email.value,
+      new_password: new_password.value,
+    })
+    .then((response) => {
+      console.log(response);
+      message.value = response.data.message;
+      icon.value = "bi-person-check";
+      title.value = "Password reset successful";
+      show_form.value = false;
+    })
+    .catch((error) => {
+      if (error.response != null) {
+        message.value = error.response.data.message;
+      } else {
+        message.value = "Cannot connect to server.";
+      }
+      icon.value = "bi-person-exclamation";
+      title.value = "Password reset failed";
+      show_form.value = false;
+    });
+}
+</script>
+
+<template>
+  <main>
+    <ListItem :title="title" :icon="icon">
+      <form @submit.prevent="reset_password" v-if="show_form">
+        <p>
+          <label for="email_current">Email address:</label>
+          <input
+            v-model="email"
+            id="email_current"
+            placeholder="your.name@uni-heidelberg.de"
+            maxlength="256"
+          />
+        </p>
+        <p>
+          <label for="passwd_new">New Password:</label>
+          <input
+            v-model="new_password"
+            id="passwd_new"
+            type="password"
+            placeholder="new password"
+            :title="new_password_message"
+            maxlength="256"
+          />
+          <span class="error-message pad-left">{{ new_password_message }}</span>
+        </p>
+        <p>
+          <label for="passwd_new2">Confirm New Password:</label>
+          <input
+            v-model="new_password2"
+            id="passwd_new2"
+            type="password"
+            placeholder="new password"
+            :title="new_password2_message"
+            maxlength="256"
+          />
+          <span class="error-message pad-left">{{
+            new_password2_message
+          }}</span>
+        </p>
+        <input
+          type="submit"
+          :title="new_password_message + ' ' + new_password2_message"
+          :disabled="
+            email.length === 0 ||
+            new_password.length === 0 ||
+            new_password2.length === 0 ||
+            new_password_message.length + new_password2_message.length > 0
+          "
+        />
+      </form>
+      <div class="message">
+        {{ message }}
+      </div>
+      <p>Go to <RouterLink to="/login">login / signup</RouterLink> page.</p>
+    </ListItem>
+  </main>
+</template>


### PR DESCRIPTION
- User can enter their email to reset their password
  - They receive an email with a reset link
  - They can then set a new password
- If an email address is entered that does not have an account
  - Same "email sent" notification displayed (for security, otherwise user emails could be identified by spamming this)
  - But email doesn't contain reset url, instead suggests user has used the wrong email
- resolves #61

also

- activation link now actually expires after 1 week, previously never actually expired
- add .docker-ignore to frontend
